### PR TITLE
Make queue poll frequency configurable.

### DIFF
--- a/certificate_agent.py
+++ b/certificate_agent.py
@@ -12,10 +12,6 @@ logging.config.dictConfig(settings.LOGGING)
 log = logging.getLogger('certificates: ' + __name__)
 
 
-# how long to wait in seconds after an xqueue poll
-SLEEP_TIME = 5
-
-
 def parse_args(args=sys.argv[1:]):
     parser = ArgumentParser(description="""
 
@@ -63,7 +59,7 @@ def main():
 
         if manager.get_length() == 0:
             log.debug("{0} has no jobs".format(str(manager)))
-            time.sleep(SLEEP_TIME)
+            time.sleep(settings.QUEUE_POLL_FREQUENCY)
             continue
         else:
             log.debug('queue length: {0}'.format(manager.get_length()))

--- a/certificate_agent.py
+++ b/certificate_agent.py
@@ -64,16 +64,6 @@ def main():
         else:
             log.debug('queue length: {0}'.format(manager.get_length()))
 
-        xqueue_body = {}
-        xqueue_header = ''
-        action = ''
-        username = ''
-        grade = None
-        course_id = ''
-        course_name = ''
-        template_pdf = None
-        name = ''
-
         certdata = manager.get_submission()
         log.debug('xqueue response: {0}'.format(certdata))
         try:

--- a/settings.py
+++ b/settings.py
@@ -20,7 +20,6 @@ ENV_ROOT = REPO_PATH.dirname()
 CERT_PRIVATE_DIR = REPO_PATH
 
 # If CERT_PRIVATE_DIR is set in the environment use it
-
 if 'CERT_PRIVATE_DIR' in os.environ:
     CERT_PRIVATE_DIR = path(os.environ['CERT_PRIVATE_DIR'])
 
@@ -31,6 +30,7 @@ CERT_DATA_FILE = 'cert-data.yml'
 
 # DEFAULTS
 DEBUG = False
+
 # This needs to be set on MacOS or anywhere you want logging to simply go
 # to an output file.
 LOGGING_DEV_ENV = True

--- a/settings.py
+++ b/settings.py
@@ -81,6 +81,9 @@ CERT_URL = ''
 CERT_DOWNLOAD_URL = ''
 CERT_VERIFY_URL = ''
 
+# This is how long in seconds the cert agent will sleep before polling the queue again.
+QUEUE_POLL_FREQUENCY = 5
+
 # load settings from env.json and auth.json
 if os.path.isfile(ENV_ROOT / "env.json"):
     with open(ENV_ROOT / "env.json") as env_file:
@@ -88,6 +91,7 @@ if os.path.isfile(ENV_ROOT / "env.json"):
     TMP_GEN_DIR = ENV_TOKENS.get('TMP_GEN_DIR', '/tmp/certificates/')
     QUEUE_NAME = ENV_TOKENS.get('QUEUE_NAME', 'test-pull')
     QUEUE_URL = ENV_TOKENS.get('QUEUE_URL', 'https://stage-xqueue.edx.org')
+    QUEUE_POLL_FREQUENCY = ENV_TOKENS.get('QUEUE_POLL_FREQUENCY', QUEUE_POLL_FREQUENCY)
     CERT_GPG_DIR = ENV_TOKENS.get('CERT_GPG_DIR', CERT_GPG_DIR)
     CERT_KEY_ID = ENV_TOKENS.get('CERT_KEY_ID', CERT_KEY_ID)
     CERT_BUCKET = ENV_TOKENS.get('CERT_BUCKET', CERT_BUCKET)


### PR DESCRIPTION
There are use cases where polling less frequently is desired, for example for performance and scaling reasons. To be able to do that though, we need the frequency to be configurable.

The complementary upstream PR is https://github.com/edx/edx-certificates/pull/56.