### PR TITLE
[BB-3112] Pin `setuptools` in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,5 @@ python-bidi==0.3.4
 PyYAML==3.11
 reportlab==3.1.44
 requests==2.3.0
+setuptools==44.1.1
 git+https://github.com/edx/opaque-keys.git@1254ed4d615a428591850656f39f26509b86d30a#egg=opaque-keys


### PR DESCRIPTION
Installing `python-bidi==0.3.4` fails while using the default version of setuptools (`45.0.0`).